### PR TITLE
changed the schema by RaSaTransaccional_ETL in all notebooks

### DIFF
--- a/ETL/ETL-Cargue-Dim-Areas-Servicio.ipynb
+++ b/ETL/ETL-Cargue-Dim-Areas-Servicio.ipynb
@@ -90,7 +90,7 @@
     "    \"driver\": \"com.mysql.cj.jdbc.Driver\"\n",
     "}\n",
     "\n",
-    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/WWImportersTransactional'\n",
+    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/RaSaTransaccional_ETL'\n",
     "destination_db_string_connection = f'jdbc:mysql://157.253.236.120:8080/{db_user}'\n",
     "\n",
     "# Driver de conexion\n",

--- a/ETL/ETL-Cargue-Dim-Fechas.ipynb
+++ b/ETL/ETL-Cargue-Dim-Fechas.ipynb
@@ -10,8 +10,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-16T13:39:56.271810Z",
-     "start_time": "2024-11-16T13:39:56.268816Z"
+     "end_time": "2024-11-16T16:38:32.336937Z",
+     "start_time": "2024-11-16T16:38:32.266872Z"
     }
    },
    "cell_type": "code",
@@ -20,11 +20,10 @@
     "from pyspark.sql.types import IntegerType, StringType, DateType, LongType\n",
     "from pyspark.sql import functions as f, SparkSession, types as t\n",
     "from pyspark import SparkContext, SparkConf, SQLContext\n",
-    "from pyspark.sql.functions import col, length\n",
-    "\n"
+    "from pyspark.sql.functions import col, length\n"
    ],
    "outputs": [],
-   "execution_count": 2
+   "execution_count": 5
   },
   {
    "cell_type": "markdown",
@@ -50,8 +49,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-16T13:39:59.561504Z",
-     "start_time": "2024-11-16T13:39:59.556957Z"
+     "end_time": "2024-11-16T16:38:35.158058Z",
+     "start_time": "2024-11-16T16:38:35.153175Z"
     }
    },
    "cell_type": "code",
@@ -88,15 +87,15 @@
     "    return spark.read.load(_PATH, format=\"csv\", sep=_sep, inferSchema=\"true\", header='true')"
    ],
    "outputs": [],
-   "execution_count": 3
+   "execution_count": 6
   },
   {
    "cell_type": "code",
    "metadata": {
     "id": "os1iJYmu86vt",
     "ExecuteTime": {
-     "end_time": "2024-11-16T14:03:35.241120Z",
-     "start_time": "2024-11-16T14:03:35.238184Z"
+     "end_time": "2024-11-16T16:38:38.287079Z",
+     "start_time": "2024-11-16T16:38:38.282905Z"
     }
    },
    "source": [
@@ -110,7 +109,7 @@
     "    \"driver\": \"com.mysql.cj.jdbc.Driver\"\n",
     "}\n",
     "\n",
-    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/RaSaTransaccional'\n",
+    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/RaSaTransaccional_ETL'\n",
     "destination_db_string_connection = f'jdbc:mysql://157.253.236.120:8080/{db_user}'\n",
     "\n",
     "# Driver de conexion\n",
@@ -120,13 +119,13 @@
     "#path_jar_driver = 'C:\\Program Files (x86)\\MySQL\\Connector J 8.0\\mysql-connector-java-8.0.28.jar'"
    ],
    "outputs": [],
-   "execution_count": 8
+   "execution_count": 7
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-16T13:40:36.484852Z",
-     "start_time": "2024-11-16T13:40:33.016452Z"
+     "end_time": "2024-11-16T16:38:44.797613Z",
+     "start_time": "2024-11-16T16:38:41.348550Z"
     }
    },
    "cell_type": "code",
@@ -136,23 +135,24 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "24/11/16 08:40:34 WARN Utils: Your hostname, willp resolves to a loopback address: 127.0.1.1; using 192.168.1.113 instead (on interface wlp9s0)\n",
-      "24/11/16 08:40:34 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
+      "24/11/16 11:38:43 WARN Utils: Your hostname, willp resolves to a loopback address: 127.0.1.1; using 192.168.1.113 instead (on interface wlp9s0)\n",
+      "24/11/16 11:38:43 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address\n",
       "Setting default log level to \"WARN\".\n",
       "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n",
-      "24/11/16 08:40:35 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "24/11/16 11:38:43 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "24/11/16 11:38:44 WARN Utils: Service 'SparkUI' could not bind on port 4040. Attempting port 4041.\n",
       "/home/willp/anaconda3/lib/python3.11/site-packages/pyspark/sql/context.py:112: FutureWarning: Deprecated in 3.0.0. Use SparkSession.builder.getOrCreate() instead.\n",
       "  warnings.warn(\n"
      ]
     }
    ],
-   "execution_count": 5
+   "execution_count": 8
   },
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-16T14:03:43.125368Z",
-     "start_time": "2024-11-16T14:03:43.118046Z"
+     "end_time": "2024-11-16T16:38:47.872467Z",
+     "start_time": "2024-11-16T16:38:47.867225Z"
     }
    },
    "cell_type": "code",
@@ -183,8 +183,8 @@
   {
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-11-16T14:06:25.171652Z",
-     "start_time": "2024-11-16T14:06:22.536278Z"
+     "end_time": "2024-11-16T16:58:58.260335Z",
+     "start_time": "2024-11-16T16:58:57.708504Z"
     }
    },
    "cell_type": "code",
@@ -194,13 +194,13 @@
     "(\n",
     "SELECT DISTINCT\n",
     "    CASE\n",
-    "        WHEN Fecha REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{7}$'\n",
-    "            THEN DATE_FORMAT(STR_TO_DATE(Fecha, '%Y-%m-%d %H:%i:%s.%f'), '%Y-%m-%d')\n",
+    "        WHEN Fecha REGEXP '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'\n",
+    "            THEN DATE_FORMAT(STR_TO_DATE(TRIM(Fecha), '%Y-%m-%d %H:%i:%s.%f'), '%Y-%m-%d')\n",
     "        WHEN Fecha REGEXP '^[A-Za-z]{3} [0-9]{1,2},[0-9]{4}$'\n",
-    "            THEN DATE_FORMAT(STR_TO_DATE(Fecha, '%b %d,%Y'), '%Y-%m-%d')\n",
-    "        ELSE 'Invalid Format'\n",
+    "            THEN DATE_FORMAT(STR_TO_DATE(TRIM(Fecha), '%b %d,%Y'), '%Y-%m-%d')\n",
+    "        ELSE concat('Invalid Format: ',Fecha)\n",
     "        END AS Fecha\n",
-    "FROM FuentePlanesBeneficio_Copia_E\n",
+    "FROM FuentePlanesBeneficio_ETL\n",
     ") AS Fecha\n",
     "'''\n",
     "df_move_date = conn_orig.get_dataframe(sql_move_date)\n",
@@ -215,42 +215,17 @@
       "+----------+\n",
       "|     Fecha|\n",
       "+----------+\n",
-      "|      null|\n",
       "|2017-12-31|\n",
+      "|2019-12-31|\n",
+      "|2020-12-31|\n",
+      "|2021-12-31|\n",
       "|2018-12-31|\n",
       "+----------+\n",
       "\n"
      ]
     }
    ],
-   "execution_count": 12
-  },
-  {
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-11-16T14:07:07.430084Z",
-     "start_time": "2024-11-16T14:07:07.103311Z"
-    }
-   },
-   "cell_type": "code",
-   "source": "df_supplier_move_date.show()",
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "+----------+\n",
-      "|     Fecha|\n",
-      "+----------+\n",
-      "|      null|\n",
-      "|2017-12-31|\n",
-      "|2018-12-31|\n",
-      "+----------+\n",
-      "\n"
-     ]
-    }
-   ],
-   "execution_count": 13
+   "execution_count": 17
   },
   {
    "metadata": {},
@@ -258,20 +233,25 @@
    "source": "## Transformation\n"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-16T16:59:00.198077Z",
+     "start_time": "2024-11-16T16:59:00.142663Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
    "source": [
     "df_supplier_move_date = df_supplier_move_date.withColumn(\n",
-    "    \"ID_Fecha\", f.date_format(\"Fecha\", \"yyyyMMdd\").cast(\"int\")\n",
+    "    \"IdFecha\", f.date_format(\"Fecha\", \"yyyyMMdd\").cast(\"int\")\n",
     ").withColumn(\n",
     "    \"Dia\", f.dayofmonth(\"Fecha\").cast(\"int\")\n",
     ").withColumn(\n",
     "    \"Mes\", f.month(\"Fecha\").cast(\"int\")\n",
     ").withColumn(\n",
-    "    \"Anio\", f.year(\"Fecha\").cast(\"int\"))"
-   ]
+    "    \"Annio\", f.year(\"Fecha\").cast(\"int\"))"
+   ],
+   "outputs": [],
+   "execution_count": 18
   },
   {
    "metadata": {},
@@ -279,11 +259,24 @@
    "source": "## Load\n"
   },
   {
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-16T16:59:04.168499Z",
+     "start_time": "2024-11-16T16:59:02.674846Z"
+    }
+   },
    "cell_type": "code",
-   "outputs": [],
-   "execution_count": null,
-   "source": "conn_dest.save_db(df_supplier_move_date, \"Fecha\")"
+   "source": "conn_dest.save_db(df_supplier_move_date, \"Rs_Fecha\")",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "                                                                                \r"
+     ]
+    }
+   ],
+   "execution_count": 19
   }
  ],
  "metadata": {

--- a/ETL/ETL-Cargue_Dim_Condiciones_pago.ipynb
+++ b/ETL/ETL-Cargue_Dim_Condiciones_pago.ipynb
@@ -89,7 +89,7 @@
     "    \"driver\": \"com.mysql.cj.jdbc.Driver\"\n",
     "}\n",
     "\n",
-    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/WWImportersTransactional'\n",
+    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/RaSaTransaccional_ETL'\n",
     "destination_db_string_connection = f'jdbc:mysql://157.253.236.120:8080/{db_user}'\n",
     "\n",
     "# Driver de conexion\n",

--- a/ETL/ETL-Cargue_Dim_Tipos_Beneficio.ipynb
+++ b/ETL/ETL-Cargue_Dim_Tipos_Beneficio.ipynb
@@ -90,7 +90,7 @@
     "    \"driver\": \"com.mysql.cj.jdbc.Driver\"\n",
     "}\n",
     "\n",
-    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/WWImportersTransactional'\n",
+    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/RaSaTransaccional_ETL'\n",
     "destination_db_string_connection = f'jdbc:mysql://157.253.236.120:8080/{db_user}'\n",
     "\n",
     "# Driver de conexion\n",

--- a/ETL/ETL-Cargue_Hecho_Carga.ipynb
+++ b/ETL/ETL-Cargue_Hecho_Carga.ipynb
@@ -41,13 +41,6 @@
    "source": "Fecha es importante para llevar el historico de las tablas hechos."
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "UpOSEfhX86vs"
-   },
-   "source": "![Modelo Movimientos](./images/Fecha.png)"
-  },
-  {
    "metadata": {
     "ExecuteTime": {
      "end_time": "2024-11-16T13:39:59.561504Z",
@@ -111,7 +104,7 @@
     "    \"driver\": \"com.mysql.cj.jdbc.Driver\"\n",
     "}\n",
     "\n",
-    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/WWImportersTransactional'\n",
+    "source_db_string_connection = 'jdbc:mysql://157.253.236.120:8080/RaSaTransaccional_ETL'\n",
     "destination_db_string_connection = f'jdbc:mysql://157.253.236.120:8080/{db_user}'\n",
     "\n",
     "# Driver de conexion\n",


### PR DESCRIPTION
This pull request updates several ETL notebooks to use the new `RaSaTransaccional_ETL` database connection, refines date extraction and transformation logic in the `ETL-Cargue-Dim-Fechas.ipynb` notebook, and improves naming conventions and output consistency. The most significant changes are grouped below:

**Database Connection Updates:**

* Changed the `source_db_string_connection` in all relevant notebooks (`ETL-Cargue-Dim-Areas-Servicio.ipynb`, `ETL-Cargue_Dim_Condiciones_pago.ipynb`, `ETL-Cargue_Dim_Tipos_Beneficio.ipynb`, `ETL-Cargue_Hecho_Carga.ipynb`, and `ETL-Cargue-Dim-Fechas.ipynb`) to point to `RaSaTransaccional_ETL` instead of `WWImportersTransactional` or `RaSaTransaccional`. This ensures all ETL processes are sourcing data from the correct database. [[1]](diffhunk://#diff-fe96f084bbf52fef1490ea3217d33d41384259819a8aaefaf629ec4366cfc392L93-R93) [[2]](diffhunk://#diff-3fea4404ff35609aa15eb18058a4d8533b927106ec86dc88caf3516993fa1dcbL92-R92) [[3]](diffhunk://#diff-be65289a5c2417e3c5e7bbd37d7e488d58705a5ff429865e1a6ff29b952107efL93-R93) [[4]](diffhunk://#diff-a1bf558184dcf4327780b48fba712aebad67c666649b60a2d6e3b6be747ed75dL114-R107) [[5]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L113-R112)

**Date Extraction and Transformation Improvements:**

* Refined the SQL query in `ETL-Cargue-Dim-Fechas.ipynb` to handle date formats more robustly, including trimming input strings, updating regex patterns, and providing clearer error messages for invalid formats. The source table was changed from `FuentePlanesBeneficio_Copia_E` to `FuentePlanesBeneficio_ETL`.
* Updated the transformation logic to rename columns for consistency (`ID_Fecha` to `IdFecha`, `Anio` to `Annio`) and changed the output table name from `Fecha` to `Rs_Fecha`.

**Output and Execution Metadata Adjustments:**

* Updated output data in `ETL-Cargue-Dim-Fechas.ipynb` to reflect new date values and removed nulls, ensuring more accurate results. Execution counts and timestamps were also updated throughout the notebook for better traceability. [[1]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L13-R14) [[2]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L53-R53) [[3]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L91-R98) [[4]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L123-R128) [[5]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L139-R155) [[6]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L186-R187) [[7]](diffhunk://#diff-54b4faa673c3a69a172246162eba7b8fe74090447e4f1349ab64b54cb4a79038L218-R279)

**Documentation and Notebook Cleanup:**

* Removed an outdated image reference from `ETL-Cargue_Hecho_Carga.ipynb` to streamline documentation.

These changes collectively improve the reliability, maintainability, and clarity of the ETL process across all affected notebooks.